### PR TITLE
Fixed relative paths for pages in root of site

### DIFF
--- a/lib/jekyll-paginate-v2/generator/paginationPage.rb
+++ b/lib/jekyll-paginate-v2/generator/paginationPage.rb
@@ -19,6 +19,7 @@ module Jekyll
         if cur_page_nr == 1
           @dir = page_to_copy.dir
           @name = page_to_copy.name
+          @relative_path = page_to_copy.relative_path
         end
 
         self.process(@name) # Creates the basename and ext member values


### PR DESCRIPTION
Jekyll's Pages have the following method:
```
def relative_path
  @relative_path ||= PathManager.join(@dir, @name).delete_prefix("/")
end
```
`@dir` is roughly equivalent to the file's `permalink`.
So for the file `blog.html` (in the root of the site files), `@dir='blog'` and `@name='blog.html'`. 

When a new `PaginationPage` is made, `@dir` and `@name` are copied over, but `@relative_path` is never set. 
This means it gets the fallback value of `PathManager.join(@dir, @name).delete_prefix("/")`. 
This results in `@relative_path` being erroneously set to `blog/blog.html`.

This pr also copies the `@relative_path` to fix this issue.